### PR TITLE
Fix Dad Jokes link on every page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,8 +17,8 @@ title: James Lakko Blog
 email: james_lakko@byu.edu
 description: >- # this means to ignore newlines until "baseurl:"
   James Lakko's github site to showcase new and exciting work.
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "jlakko.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/jlakko.github.io" # the subpath of your site, e.g. /blog
+url: "https://jlakko.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: sparkyscout
 github_username:  jlakko
 

--- a/_site/index.html
+++ b/_site/index.html
@@ -13,7 +13,7 @@
 <meta property="og:url" content="http://localhost:4000/" />
 <meta property="og:site_name" content="Your awesome title" />
 <script type="application/ld+json">
-{"@type":"WebSite","url":"http://localhost:4000/","name":"Your awesome title","headline":"Your awesome title","description":"Write an awesome description for your new site here. You can edit this line in _config.yml. It will appear in your document head meta (for Google search results) and in your feed.xml site description.","@context":"https://schema.org"}</script>
+{"@type":"WebSite","url":"http://localhost:4000/","name":"Your awesome title","headline":"Your awesome title","description":"Write an awesome description for your new site here. You can edit this line in your _config.yml. It will appear in your document head meta (for Google search results) and in your feed.xml site description.","@context":"https://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 <link rel="stylesheet" href="/assets/main.css"><link type="application/atom+xml" rel="alternate" href="http://localhost:4000/feed.xml" title="Your awesome title" /></head>
 <body><header class="site-header" role="banner">
@@ -28,7 +28,7 @@
           </span>
         </label>
 
-        <div class="trigger"><a class="page-link" href="/about/">About</a></div>
+        <div class="trigger"><a class="page-link" href="/about/">About</a><a class="page-link" href="/dad-jokes/">Dad Jokes</a></div>
       </nav></div>
 </header>
 <main class="page-content" aria-label="Content">

--- a/dad-jokes.md
+++ b/dad-jokes.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Dad Jokes
+permalink: /dad-jokes/
 ---
 
 # Dad Jokes


### PR DESCRIPTION
Add a link to the "Dad Jokes" page in the navigation menu on every page.

* **dad-jokes.md**
  - Add front matter to ensure the file is processed by Jekyll.
  - Ensure the file is located in the root directory of the repository.

* **_config.yml**
  - Update `baseurl` to the correct subpath if the site is hosted on a subpath.
  - Ensure `url` is set to the correct URL for the site.

* **_site/index.html**
  - Add a link to the "Dad Jokes" page in the navigation menu.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jlakko/jlakko.github.io?shareId=e010ce1f-7772-44f5-b5e3-8348be84aa51).